### PR TITLE
bodeplotter improved performance

### DIFF
--- a/utilities/bodeplotter.m
+++ b/utilities/bodeplotter.m
@@ -21,7 +21,7 @@ if strcmp(opt,'magphase')
 end
 
 if ~strcmp(opt,'phase')
-    set(ha(1), 'ColorOrder', col, 'NextPlot', 'replacechildren');
+    set(gca, 'ColorOrder', col, 'NextPlot', 'replacechildren');
     semilogx(w,imag(tpl),'linewidth',linespec.width,'linestyle',linespec.style);  
     %if strcmp(CASE,'all') || strcmp(CASE,'nom')
     %    [w_nom,t_nom]=gettpl(tplf,'nom');
@@ -38,7 +38,7 @@ if strcmp(opt,'magphase')
 end
 
 if ~strcmp(opt,'mag')
-    set(ha(1), 'ColorOrder', col, 'NextPlot', 'replacechildren');
+    set(gca, 'ColorOrder', col, 'NextPlot', 'replacechildren');
     semilogx(w,real(tpl),'linewidth',linespec.width,'linestyle',linespec.style);
     %if strcmp(CASE,'all') || strcmp(CASE,'nom')
     %    phase=real(t_nom);

--- a/utilities/bodeplotter.m
+++ b/utilities/bodeplotter.m
@@ -21,7 +21,8 @@ if strcmp(opt,'magphase')
 end
 
 if ~strcmp(opt,'phase')
-    set(gca, 'ColorOrder', col, 'NextPlot', 'replacechildren');
+    hold on
+    set(gca, 'ColorOrder', col, 'NextPlot', 'add','XScale','log');
     semilogx(w,imag(tpl),'linewidth',linespec.width,'linestyle',linespec.style);  
     %if strcmp(CASE,'all') || strcmp(CASE,'nom')
     %    [w_nom,t_nom]=gettpl(tplf,'nom');
@@ -38,7 +39,8 @@ if strcmp(opt,'magphase')
 end
 
 if ~strcmp(opt,'mag')
-    set(gca, 'ColorOrder', col, 'NextPlot', 'replacechildren');
+    hold on
+    set(gca, 'ColorOrder', col, 'NextPlot', 'add','XScale','log');
     semilogx(w,real(tpl),'linewidth',linespec.width,'linestyle',linespec.style);
     %if strcmp(CASE,'all') || strcmp(CASE,'nom')
     %    phase=real(t_nom);

--- a/utilities/bodeplotter.m
+++ b/utilities/bodeplotter.m
@@ -21,11 +21,8 @@ if strcmp(opt,'magphase')
 end
 
 if ~strcmp(opt,'phase')
-    for k=1:N
-        semilogx(w,imag(tpl(k,:)),'Color',col(k,:),'Tag',num2str(k),...
-            'linewidth',linespec.width,'linestyle',linespec.style);
-        hold on
-    end
+    set(ha(1), 'ColorOrder', col, 'NextPlot', 'replacechildren');
+    semilogx(w,imag(tpl),'linewidth',linespec.width,'linestyle',linespec.style);  
     %if strcmp(CASE,'all') || strcmp(CASE,'nom')
     %    [w_nom,t_nom]=gettpl(tplf,'nom');
     %    semilogx(w_nom,imag(t_nom),'--k','linewidth',2);
@@ -41,16 +38,8 @@ if strcmp(opt,'magphase')
 end
 
 if ~strcmp(opt,'mag')
-    for k=1:N
-        phase=real(tpl(k,:));
-        %phase=unwrap(phase*pi/180)*180/pi;
-        %if phase(1) > 5
-        %    phase=phase-360;
-        %end
-        semilogx(w,phase,'Color',col(k,:),'Tag',num2str(k),...
-             'linewidth',linespec.width,'linestyle',linespec.style); 
-         hold on
-    end
+    set(ha(1), 'ColorOrder', col, 'NextPlot', 'replacechildren');
+    semilogx(w,real(tpl),'linewidth',linespec.width,'linestyle',linespec.style);
     %if strcmp(CASE,'all') || strcmp(CASE,'nom')
     %    phase=real(t_nom);
     %    phase=unwrap(phase*pi/180)*180/pi;

--- a/utilities/nicholsplotter.m
+++ b/utilities/nicholsplotter.m
@@ -10,11 +10,11 @@ function ha = nicholsplotter(tpl,w,col,linespec)
 
 
 N = size(tpl,1);
+hold on
 for k=1:N
     plot(real(tpl(k,:)),imag(tpl(k,:)),'Zdata',w,...
         'Color',col(k,:),'Tag',num2str(k),...
-        'linewidth',linespec.width,'linestyle',linespec.style);
-    hold on
+        'linewidth',linespec.width,'linestyle',linespec.style); 
 end
 hold off   
 ha = gca;


### PR DESCRIPTION
Plotting with matrices greatly enhances performance. The original version looped twice on all the cases while running "hold" in each iteration. Tested on the simple SISO example parameters on my machine performance of the original "P.bodcases()" was 12.209 seconds, with this version run time is down to 3.862 seconds. @rubindan 